### PR TITLE
Improvement on the Error Message related to Shared App

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -183,7 +183,8 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
         // If the shared application cannot be found for the particular organization,
         // will set a "organizationLoginFailure" property in the context and will check this in Authentication Process.
         try {
-            sharedApplication = getSharedApplication(application, ownerOrgId, sharedOrgId);
+            sharedApplication = getOrgApplicationManager()
+                    .resolveSharedApplication(application, ownerOrgId, sharedOrgId);
         } catch (OrganizationManagementClientException e) {
             context.setProperty(ORGANIZATION_LOGIN_FAILURE, "Organization is not associated with this application");
             redirectToOrgNameCapture(response, context);
@@ -363,23 +364,6 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
     private void addQueryParam(StringBuilder builder, String query, String param) throws UnsupportedEncodingException {
 
         builder.append(AMPERSAND_SIGN).append(query).append(EQUAL_SIGN).append(urlEncode(param));
-    }
-
-    /**
-     * Returns the shared application details based on the given organization name, main application and owner
-     * organization of the main application.
-     *
-     * @param application Main application.
-     * @param ownerOrgId  Identifier of the organization which owns the main application.
-     * @param sharedOrgId Identifier of the organization which owns the shared application.
-     * @return shared application, instance of {@link ServiceProvider}.
-     * @throws OrganizationManagementException if the application, owner Tenant Domain is not found,
-     * authentication failed exception will be thrown.
-     */
-    private ServiceProvider getSharedApplication(String application, String ownerOrgId, String sharedOrgId)
-            throws OrganizationManagementException {
-
-        return getOrgApplicationManager().resolveSharedApplication(application, ownerOrgId, sharedOrgId);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -186,7 +186,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
             sharedApplication = getOrgApplicationManager()
                     .resolveSharedApplication(application, ownerOrgId, sharedOrgId);
         } catch (OrganizationManagementClientException e) {
-            context.setProperty(ORGANIZATION_LOGIN_FAILURE, "Organization is not associated with this application");
+            context.setProperty(ORGANIZATION_LOGIN_FAILURE, "Organization is not associated with this application.");
             redirectToOrgNameCapture(response, context);
             return;
         } catch (OrganizationManagementException e) {

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -126,48 +126,72 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
     protected void initiateAuthenticationRequest(HttpServletRequest request, HttpServletResponse response,
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
-        resolvePropertiesForAuthenticator(context);
-        super.initiateAuthenticationRequest(request, response, context);
+        // Removed the property when setting it in shared application client exception check
+        context.removeProperty(ORGANIZATION_LOGIN_FAILURE);
+        resolvePropertiesForAuthenticator(context, response);
+        // Check if the "organizationLoginFailure" property in the context,
+        // when added in shared application client exception check.
+        if (!context.getProperties().containsKey(ORGANIZATION_LOGIN_FAILURE)) {
+            super.initiateAuthenticationRequest(request, response, context);
+        }
     }
 
     @Override
     protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
-        resolvePropertiesForAuthenticator(context);
-        super.processAuthenticationResponse(request, response, context);
+        // Removed the property when setting it in shared application client exception check
+        context.removeProperty(ORGANIZATION_LOGIN_FAILURE);
+        resolvePropertiesForAuthenticator(context, response);
+        // Check if the "organizationLoginFailure" property in the context,
+        // when added in shared application client exception check.
+        if (!context.getProperties().containsKey(ORGANIZATION_LOGIN_FAILURE)) {
+            super.processAuthenticationResponse(request, response, context);
 
-        // Add organization name to the user attributes.
-        context.getSubject().getUserAttributes()
-                .put(ClaimMapping.build(ORGANIZATION_USER_ATTRIBUTE, ORGANIZATION_USER_ATTRIBUTE, null, false),
-                        context.getAuthenticatorProperties().get(ORGANIZATION_ATTRIBUTE));
+            // Add organization name to the user attributes.
+            context.getSubject().getUserAttributes()
+                    .put(ClaimMapping.build(ORGANIZATION_USER_ATTRIBUTE, ORGANIZATION_USER_ATTRIBUTE, null, false),
+                            context.getAuthenticatorProperties().get(ORGANIZATION_ATTRIBUTE));
+        }
     }
 
     /**
      * Process the authenticator properties based on the user information.
      *
      * @param context The authentication context.
+     * @param response servlet response.
      * @throws AuthenticationFailedException thrown when resolving organization login authenticator properties.
      */
-    private void resolvePropertiesForAuthenticator(AuthenticationContext context) throws AuthenticationFailedException {
+    private void resolvePropertiesForAuthenticator(AuthenticationContext context, HttpServletResponse response)
+            throws AuthenticationFailedException {
 
         Map<String, String> authenticatorProperties = context.getAuthenticatorProperties();
 
+        String application = context.getServiceProviderName();
+        String ownerTenantDomain = context.getTenantDomain();
+
+        if (!context.getProperties().containsKey(ORG_PARAMETER) || !context.getProperties()
+                .containsKey(ORG_ID_PARAMETER)) {
+            throw handleAuthFailures(ERROR_CODE_ORG_PARAMETERS_NOT_RESOLVED);
+        }
+        String organizationName = context.getProperty(ORG_PARAMETER).toString();
+
+        // Get the shared service provider based on the requested organization.
+        String ownerOrgId = getOrgIdByTenantDomain(ownerTenantDomain);
+        String sharedOrgId = context.getProperty(ORG_ID_PARAMETER).toString();
+        ServiceProvider sharedApplication;
+        // If the shared application cannot be found for the particular organization,
+        // will set a "organizationLoginFailure" property in the context and will check this in Authentication Process.
         try {
-            String application = context.getServiceProviderName();
-            String ownerTenantDomain = context.getTenantDomain();
-
-            if (!context.getProperties().containsKey(ORG_PARAMETER) || !context.getProperties()
-                    .containsKey(ORG_ID_PARAMETER)) {
-                throw handleAuthFailures(ERROR_CODE_ORG_PARAMETERS_NOT_RESOLVED);
-            }
-            String organizationName = context.getProperty(ORG_PARAMETER).toString();
-
-            // Get the shared service provider based on the requested organization.
-            String ownerOrgId = getOrgIdByTenantDomain(ownerTenantDomain);
-            String sharedOrgId = context.getProperty(ORG_ID_PARAMETER).toString();
-            ServiceProvider sharedApplication = getSharedApplication(application, ownerOrgId, sharedOrgId);
-
+            sharedApplication = getSharedApplication(application, ownerOrgId, sharedOrgId);
+        } catch (OrganizationManagementClientException e) {
+            context.setProperty(ORGANIZATION_LOGIN_FAILURE, "Organization is not associated with this application");
+            redirectToOrgNameCapture(response, context);
+            return;
+        } catch (OrganizationManagementException e) {
+            throw handleAuthFailures(ERROR_CODE_ERROR_RETRIEVING_APPLICATION, e);
+        }
+        try {
             InboundAuthenticationRequestConfig oidcConfigurations =
                     getAuthenticationConfig(sharedApplication).orElseThrow(
                             () -> handleAuthFailures(ERROR_CODE_INVALID_APPLICATION));
@@ -349,17 +373,13 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
      * @param ownerOrgId  Identifier of the organization which owns the main application.
      * @param sharedOrgId Identifier of the organization which owns the shared application.
      * @return shared application, instance of {@link ServiceProvider}.
-     * @throws AuthenticationFailedException if the application is not found, authentication failed exception will be
-     *                                       thrown.
+     * @throws OrganizationManagementException if the application, owner Tenant Domain is not found,
+     * authentication failed exception will be thrown.
      */
     private ServiceProvider getSharedApplication(String application, String ownerOrgId, String sharedOrgId)
-            throws AuthenticationFailedException {
+            throws OrganizationManagementException {
 
-        try {
-            return getOrgApplicationManager().resolveSharedApplication(application, ownerOrgId, sharedOrgId);
-        } catch (OrganizationManagementException e) {
-            throw handleAuthFailures(ERROR_CODE_ERROR_RETRIEVING_APPLICATION, e);
-        }
+        return getOrgApplicationManager().resolveSharedApplication(application, ownerOrgId, sharedOrgId);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Improvement on the error message when an organization tries to log in when an application is not shared with the organization

## Goals
> Provide a proper error message when a user tries to log in to an organization, where the SaaS app is not shared.

## Approach
> Try to get the shared application within the authentication flow.

> Set a context property when client exception occurred when retrieving the shared app.

> Checked the set property in the authentication flow before calling to the super method and escaped from auth flow.

> Removed set property after that, since that property is also used in the process method when validating the organization name. So had to remove it from the context.

## User stories
> Customer trying to login into an application providing an organization name, which does not have that particular application shared with that organization.

> Provide an error message

![image](https://user-images.githubusercontent.com/59449070/182694484-9a267e0f-866a-4d3e-8c69-1b8deecbff70.png)

## Samples
> Reproduce the error using pickup-dispatch app configuring with OIDC protocol

## Related Issues
> * https://github.com/wso2/product-is/issues/14420