### PR TITLE
Add support to apply parent organization's URL branding to sub organizations

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
@@ -29,8 +29,8 @@ public class AuthenticatorConstants {
     public static final String AUTHENTICATOR_NAME = "OrganizationAuthenticator";
     public static final String AUTHENTICATOR_FRIENDLY_NAME = "OrganizationLogin";
 
-    public static final String AUTHORIZATION_ENDPOINT_ORGANIZATION_PATH = "o/{organization}/oauth2/authorize";
-    public static final String TOKEN_ENDPOINT_ORGANIZATION_PATH = "o/{organization}/oauth2/token";
+    public static final String AUTHORIZATION_ENDPOINT_ORGANIZATION_PATH = "oauth2/authorize";
+    public static final String TOKEN_ENDPOINT_ORGANIZATION_PATH = "oauth2/token";
     public static final String ORGANIZATION_PLACEHOLDER = "{organization}";
 
     public static final String ORGANIZATION_ATTRIBUTE = "Organization";

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>5.25.0</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.70</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 6.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
$ subject
In this PR o/{org-id} part is removed from the path passed to the service URL builder and organization id is manually set when calling the service URL builder in order to support applying hostname branding to Asgardeo sub organizations.

Depends on https://github.com/wso2/carbon-identity-framework/pull/4372