### PR TITLE
Fix organization login failure when no user attributes defined in the app.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -506,7 +506,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
 
     private String getRequestedClaims(ClaimMapping[] claimMappings, String tenantDomain) throws ClaimMetadataException {
 
-        if (claimMappings != null) {
+        if (claimMappings != null && claimMappings.length > 0) {
             StringBuilder paramBuilder = new StringBuilder("&claims={\"userinfo\":{");
             for (ClaimMapping claimMapping : claimMappings) {
                 String oidcClaim = StringUtils.EMPTY;


### PR DESCRIPTION
## Purpose

Organization login flow fails when no user attributes defined in the B2B application.

Check the final part of the `/authorize` request URL in below image.

<img width="1415" alt="Screenshot 2023-10-17 at 01 10 39" src="https://github.com/wso2-extensions/identity-auth-organization-login/assets/35717390/9bba6da0-4e86-4f11-82e6-d2c763ae943f">