### PR TITLE
When SAML Response is Available in the Request, Initiate Auth Request as POST

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/pom.xml
@@ -117,6 +117,10 @@
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
@@ -171,6 +175,8 @@
 
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+
+                            org.owasp.encoder,
 
                             org.wso2.carbon.extension.identity.helper; version="${identity.extension.utils.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework; version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -67,4 +67,6 @@ public class AuthenticatorConstants {
     public static final String AMPERSAND_SIGN = "&";
     public static final String ID_TOKEN_ORG_ID_PARAM = "org_id";
     public static final String OIDC_CLAIM_DIALECT_URL = "http://wso2.org/oidc/claim";
+
+    public static final String SAML_RESP = "SAMLResponse";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
                 <version>${findbugs.annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
+                <artifactId>encoder</artifactId>
+                <version>${encoder.wso2.version}</version>
+            </dependency>
 
             <!--Test Dependencies-->
             <dependency>
@@ -401,6 +406,8 @@
 
         <oltu.oauth2.client.version>1.0.0</oltu.oauth2.client.version>
         <oltu.oauth2.client.version.range>[1.0.0,1.0.3)</oltu.oauth2.client.version.range>
+
+        <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
 
         <mockito-core.version>4.6.1</mockito-core.version>
         <jacoco.version>0.8.2</jacoco.version>


### PR DESCRIPTION
### Purpose
- In SAML IdP initiated login flow, SAML response is passed as a POST parameter to `OrganizationAuthenticator`. But when sub org auth request is initiated as a GET, this SAML response is lost. Therefore, with this PR, sub org auth request is initiated as a POST request containing SAML response as body parameter.

### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/177