### PR TITLE
Add `spId` Query Param into Org Discovery Input Capture Redirect URL

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -127,6 +127,7 @@ import static org.wso2.carbon.identity.application.authenticator.organization.lo
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.REQUEST_ORG_PAGE_URL;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.REQUEST_ORG_PAGE_URL_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.REQUEST_ORG_SELECT_PAGE_URL;
+import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.SP_ID_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.TOKEN_ENDPOINT_ORGANIZATION_PATH;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.USERINFO_ENDPOINT_ORGANIZATION_PATH;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.USERINFO_URL;
@@ -580,6 +581,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
                     .append(urlEncode(context.getContextIdentifier()));
             addQueryParam(queryStringBuilder, IDP_PARAMETER, context.getExternalIdP().getName());
             addQueryParam(queryStringBuilder, AUTHENTICATOR_PARAMETER, getName());
+            addQueryParam(queryStringBuilder, SP_ID_PARAMETER, context.getServiceProviderResourceId());
             boolean discoveryEnabled = isOrganizationDiscoveryEnabled(context);
             if (discoveryEnabled) {
                 addQueryParam(queryStringBuilder, ORG_DISCOVERY_ENABLED_PARAMETER, "true");

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
@@ -52,6 +52,7 @@ public class AuthenticatorConstants {
     public static final String ORGANIZATION_NAME = "orgName";
     public static final String ENABLE_CONFIG = ".enable";
     public static final String LOGIN_HINT_PARAMETER = "login_hint";
+    public static final String SP_ID_PARAMETER = "spId";
 
     public static final String ORGANIZATION_LOGIN_FAILURE = "organizationLoginFailure";
     public static final String ERROR_MESSAGE = "&authFailure=true&authFailureMsg=";

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/test/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/test/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -94,6 +94,7 @@ public class OrganizationAuthenticatorTest {
     private static final String orgId = "ef35863f-58f0-4a18-aef1-a8d9dd20cfbe";
     private static final String org = "greater";
     private static final String saasApp = "medlife";
+    private static final String saasAppResourceId = "4f412c8a-ace8-4189-bbfb-c7c0d93b8662";
     private static final String saasAppOwnedTenant = "carbon.super";
     private static final String saasAppOwnedOrgId = "10084a8d-113f-4211-a0d5-efe36b082211";
     private static final String clientId = "3_TCRZ93rTQtPL8k02_trEYTfVca";
@@ -221,6 +222,7 @@ public class OrganizationAuthenticatorTest {
 
         when(mockAuthenticationContext.getContextIdentifier()).thenReturn(contextIdentifier);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(mockExternalIdPConfig);
+        when(mockAuthenticationContext.getServiceProviderResourceId()).thenReturn(saasAppResourceId);
         when(mockExternalIdPConfig.getName()).thenReturn(AUTHENTICATOR_FRIENDLY_NAME);
 
         when(authenticatorDataHolder.getOrganizationConfigManager().getDiscoveryConfiguration())
@@ -243,6 +245,7 @@ public class OrganizationAuthenticatorTest {
 
         when(mockAuthenticationContext.getContextIdentifier()).thenReturn(contextIdentifier);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(mockExternalIdPConfig);
+        when(mockAuthenticationContext.getServiceProviderResourceId()).thenReturn(saasAppResourceId);
         when(mockExternalIdPConfig.getName()).thenReturn(AUTHENTICATOR_FRIENDLY_NAME);
 
         when(authenticatorDataHolder.getOrganizationConfigManager().getDiscoveryConfiguration())
@@ -289,6 +292,7 @@ public class OrganizationAuthenticatorTest {
         when(mockAuthenticationContext.getContextIdentifier()).thenReturn(contextIdentifier);
         when(mockAuthenticationContext.getExternalIdP()).thenReturn(mockExternalIdPConfig);
         when(mockAuthenticationContext.getServiceProviderName()).thenReturn(saasApp);
+        when(mockAuthenticationContext.getServiceProviderResourceId()).thenReturn(saasAppResourceId);
         when(mockAuthenticationContext.getTenantDomain()).thenReturn(saasAppOwnedTenant);
         when(mockExternalIdPConfig.getName()).thenReturn(AUTHENTICATOR_FRIENDLY_NAME);
 


### PR DESCRIPTION
## Purpose
> To apply application branding to Organization Discovery Input Capture page (Sign In With SSO page), the application ID must be included as a query parameter in the URL. Hence, this PR adds `spId` param into the redirect URL which in turns load the said page with the appropriate application branding.
