### PR TITLE
Update "discoveryType" Param to "orgDiscoveryType"

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -120,6 +120,7 @@ import static org.wso2.carbon.identity.application.authenticator.organization.lo
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_DESCRIPTION_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_DISCOVERY_ENABLED_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_DISCOVERY_PARAMETER;
+import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_DISCOVERY_TYPE_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_ID_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.PROMPT_PARAMETER;
@@ -544,8 +545,8 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
 
         // Default discovery type is set to `emailDomain`.
         String discoveryType = EMAIL_DOMAIN_DISCOVERY_TYPE;
-        if (request.getParameterMap().containsKey(ORGANIZATION_DISCOVERY_TYPE)) {
-            discoveryType = request.getParameter(ORGANIZATION_DISCOVERY_TYPE);
+        if (request.getParameterMap().containsKey(ORG_DISCOVERY_TYPE_PARAMETER)) {
+            discoveryType = request.getParameter(ORG_DISCOVERY_TYPE_PARAMETER);
         }
 
         if (!isOrganizationDiscoveryTypeEnabled(discoveryType)) {

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
@@ -47,6 +47,7 @@ public class AuthenticatorConstants {
     public static final String ORG_DESCRIPTION_PARAMETER = "orgDesc";
     public static final String ORG_DISCOVERY_PARAMETER = "orgDiscovery";
     public static final String ORG_DISCOVERY_ENABLED_PARAMETER = "orgDiscoveryEnabled";
+    public static final String ORG_DISCOVERY_TYPE_PARAMETER = "orgDiscoveryType";
     public static final String PROMPT_PARAMETER = "prompt";
     public static final String ORGANIZATION_DISCOVERY_TYPE = "discoveryType";
     public static final String ORGANIZATION_NAME = "orgName";

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/test/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/test/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticatorTest.java
@@ -82,7 +82,7 @@ import static org.wso2.carbon.identity.application.authenticator.organization.lo
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.INBOUND_AUTH_TYPE_OAUTH;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.LOGIN_HINT_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.OIDC_CLAIM_DIALECT_URL;
-import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORGANIZATION_DISCOVERY_TYPE;
+import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_DISCOVERY_TYPE_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_ID_PARAMETER;
 import static org.wso2.carbon.identity.application.authenticator.organization.login.constant.AuthenticatorConstants.ORG_PARAMETER;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_APPLICATION_NOT_SHARED;
@@ -482,10 +482,10 @@ public class OrganizationAuthenticatorTest {
 
         Map<String, String[]> mockParamMap = new HashMap<>();
         mockParamMap.put(LOGIN_HINT_PARAMETER, new String[]{userEmail});
-        mockParamMap.put(ORGANIZATION_DISCOVERY_TYPE, new String[]{discoveryType});
+        mockParamMap.put(ORG_DISCOVERY_TYPE_PARAMETER, new String[]{discoveryType});
         when(mockServletRequest.getParameterMap()).thenReturn(mockParamMap);
         when(mockServletRequest.getParameter(LOGIN_HINT_PARAMETER)).thenReturn(userEmail);
-        when(mockServletRequest.getParameter(ORGANIZATION_DISCOVERY_TYPE)).thenReturn(discoveryType);
+        when(mockServletRequest.getParameter(ORG_DISCOVERY_TYPE_PARAMETER)).thenReturn(discoveryType);
 
         when(authenticatorDataHolder.getOrganizationConfigManager().getDiscoveryConfiguration())
                 .thenReturn(mockDiscoveryConfig);


### PR DESCRIPTION
## Purpose
- Since `orgDiscoveryType` is more descriptive and meaningful, newly introduced `discoveryType` param is changed to `orgDiscoveryType`.
- If in future, email domain based organization discovery capability is extended to discover the organization of the user based on different user attributes other than email domain,`orgDiscoveryType` query param can be used to pass in the relevant discovery type.

## Related Issues
- https://github.com/wso2/product-is/issues/20953

## Related PRs
- https://github.com/wso2-extensions/identity-auth-organization-login/pull/45
- https://github.com/wso2-extensions/identity-auth-organization-login/pull/46
- https://github.com/wso2/identity-apps/pull/6805