### PR TITLE
Add support for email domain based organization discovery during self-registration.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/constant/AuthenticatorConstants.java
@@ -49,6 +49,8 @@ public class AuthenticatorConstants {
     public static final String ORG_DISCOVERY_ENABLED_PARAMETER = "orgDiscoveryEnabled";
     public static final String ORG_DISCOVERY_TYPE_PARAMETER = "orgDiscoveryType";
     public static final String PROMPT_PARAMETER = "prompt";
+    public static final String SELF_REGISTRATION_PARAMETER = "isSelfRegistration";
+    public static final String USERNAME_PARAMETER = "discoveredUsername";
     public static final String ORGANIZATION_DISCOVERY_TYPE = "discoveryType";
     public static final String ORGANIZATION_NAME = "orgName";
     public static final String ENABLE_CONFIG = ".enable";


### PR DESCRIPTION
## Purpose
This PR improves the organization SSO authenticator to allow the use of existing organization discovery capabilities during the self-registration flow as well. 

Two new parameters are used to enable this capability
- `isSelfRegistration`: This is used in the organization discovery page to conditionally render organization name based organization discovery content. (organization name based discovery capability is not provided in the self-registration flow)
- `discoveredUsername`: This is resolved from the provided username in domain discovery page. Used to auto complete the email in the self-registration page

### Related issue
- https://github.com/wso2/product-is/issues/21596