### PR TITLE
Fix looping login flow when org id is invalid

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -512,7 +512,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
         try {
             return getOrganizationManager().getOrganizationNameById(organizationId);
         } catch (OrganizationManagementException e) {
-            log.error(e.getMessage());
+            log.debug(e.getMessage());
             return null;
         }
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -145,11 +145,9 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RESOLVING_TENANT_DOMAIN_FROM_ORGANIZATION_DOMAIN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATIONS_BY_NAME;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_NAME_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_VALIDATING_ORGANIZATION_DISCOVERY_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_VALIDATING_ORGANIZATION_LOGIN_HINT_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_APPLICATION;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORG_PARAMETERS_NOT_RESOLVED;
 
@@ -422,12 +420,16 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
             String organizationId = (String) request.getAttribute(ORG_ID_PARAMETER);
             context.setProperty(ORG_ID_PARAMETER, organizationId);
             String organizationName = getOrganizationNameById(organizationId);
-            context.setProperty(ORG_PARAMETER, organizationName);
+            if (organizationName != null) {
+                context.setProperty(ORG_PARAMETER, organizationName);
+            }
         } else if (request.getParameterMap().containsKey(ORG_ID_PARAMETER)) {
             String organizationId = request.getParameter(ORG_ID_PARAMETER);
             context.setProperty(ORG_ID_PARAMETER, organizationId);
             String organizationName = getOrganizationNameById(organizationId);
-            context.setProperty(ORG_PARAMETER, organizationName);
+            if (organizationName != null) {
+                context.setProperty(ORG_PARAMETER, organizationName);
+            }
         } else if (request.getParameterMap().containsKey(LOGIN_HINT_PARAMETER)) {
             String loginHint = request.getParameter(LOGIN_HINT_PARAMETER);
             context.setProperty(ORG_DISCOVERY_PARAMETER, loginHint);
@@ -505,14 +507,13 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
         return StringUtils.EMPTY;
     }
 
-    private String getOrganizationNameById(String organizationId) throws AuthenticationFailedException {
+    private String getOrganizationNameById(String organizationId) {
 
         try {
             return getOrganizationManager().getOrganizationNameById(organizationId);
-        } catch (OrganizationManagementClientException e) {
-            throw handleAuthFailures(ERROR_CODE_INVALID_ORGANIZATION_ID);
         } catch (OrganizationManagementException e) {
-            throw handleAuthFailures(ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_NAME_BY_ID, e);
+            log.error(e.getMessage());
+            return null;
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -420,14 +420,14 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
             String organizationId = (String) request.getAttribute(ORG_ID_PARAMETER);
             context.setProperty(ORG_ID_PARAMETER, organizationId);
             String organizationName = getOrganizationNameById(organizationId);
-            if (organizationName != null) {
+            if (StringUtils.isNotBlank(organizationName)) {
                 context.setProperty(ORG_PARAMETER, organizationName);
             }
         } else if (request.getParameterMap().containsKey(ORG_ID_PARAMETER)) {
             String organizationId = request.getParameter(ORG_ID_PARAMETER);
             context.setProperty(ORG_ID_PARAMETER, organizationId);
             String organizationName = getOrganizationNameById(organizationId);
-            if (organizationName != null) {
+            if (StringUtils.isNotBlank(organizationName)) {
                 context.setProperty(ORG_PARAMETER, organizationName);
             }
         } else if (request.getParameterMap().containsKey(LOGIN_HINT_PARAMETER)) {

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/test/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/test/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticatorTest.java
@@ -311,13 +311,21 @@ public class OrganizationAuthenticatorTest {
         Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
     }
 
-    @Test(expectedExceptions = {AuthenticationFailedException.class})
+    @Test
     public void testProcessInvalidOrgIdParam() throws Exception {
 
         setupMockParam(ORG_ID_PARAMETER, orgId);
         when(authenticatorDataHolder.getOrganizationManager().getOrganizationNameById(anyString()))
                 .thenThrow(handleClientException(ERROR_CODE_INVALID_ORGANIZATION_ID));
-        organizationAuthenticator.process(mockServletRequest, mockServletResponse, mockAuthenticationContext);
+        when(mockAuthenticationContext.getContextIdentifier()).thenReturn(contextIdentifier);
+        when(mockAuthenticationContext.getExternalIdP()).thenReturn(mockExternalIdPConfig);
+        when(mockAuthenticationContext.getServiceProviderResourceId()).thenReturn(saasAppResourceId);
+        when(mockExternalIdPConfig.getName()).thenReturn(AUTHENTICATOR_FRIENDLY_NAME);
+        when(authenticatorDataHolder.getOrganizationConfigManager().getDiscoveryConfiguration())
+                .thenReturn(mockDiscoveryConfig);
+        AuthenticatorFlowStatus status =
+                organizationAuthenticator.process(mockServletRequest, mockServletResponse, mockAuthenticationContext);
+        Assert.assertEquals(status, AuthenticatorFlowStatus.INCOMPLETE);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
$Subject
Fix https://github.com/wso2/product-is/issues/23249

## Approach
- Loop happens due to not completing the authentication sequence on authentication failure. So the while loop of https://github.com/wso2/carbon-identity-framework/blame/a8d512410a4cc4071e87195a913d245b63f213fb/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java#L110 is executed infinitely
 - This happens only if the failing authenticator existing step has multi options https://github.com/wso2/carbon-identity-framework/blame/a8d512410a4cc4071e87195a913d245b63f213fb/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/sequence/impl/DefaultStepBasedSequenceHandler.java#L170-L172
 - In OrganizationSSO case, if the fidp is selected and invalid organization id is selected, nothing is prompted to user to retry and it goes infinitely with same inputs in the initial request.
 - Therefore, from OrganizationSSO authenticator side, fail the request with sending INCOMPLETE state to ask for user input for organization name 

<!--
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.
-->