### PR TITLE
Internal urls for sub-organization login internal calls

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -984,7 +984,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
     private String getUserInfoEndpoint(String organizationId, String tenantDomain) throws URLBuilderException {
 
         return ServiceURLBuilder.create().addPath(USERINFO_ENDPOINT_ORGANIZATION_PATH).setTenant(tenantDomain)
-                .setOrganization(organizationId).build().getAbsolutePublicURL();
+                .setOrganization(organizationId).build().getAbsoluteInternalURL();
     }
 
     /**
@@ -997,7 +997,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
     private String getTokenEndpoint(String organizationId, String tenantDomain) throws URLBuilderException {
 
         return ServiceURLBuilder.create().addPath(TOKEN_ENDPOINT_ORGANIZATION_PATH).setTenant(tenantDomain)
-                .setOrganization(organizationId).build().getAbsolutePublicURL();
+                .setOrganization(organizationId).build().getAbsoluteInternalURL();
     }
 
     /**


### PR DESCRIPTION
## Purpose
The internal `/token` call and `/userinfo` API calls happen during the organization SSO authenticator is not required to be domain qualified URL, having it qualified with internal URL should be enough. 
This will reduce the DNS resolving cost, request leaving the host and received back (additional hops) and SSL errors which occurs for the internal API calls with different domains which the default trust store doesn't accept.

### Related Issues
- https://github.com/wso2/product-is/issues/23894