### PR TITLE
Add support for org discovery parameters via adaptive script

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -445,8 +445,9 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
                 context.removeProperty(ORG_DISCOVERY_PARAMETER);
                 return AuthenticatorFlowStatus.INCOMPLETE;
             }
-        } else if (isParameterExists(request, runtimeParams, ORG_DISCOVERY_PARAMETER)) {
-            String discoveryInput = getParameter(request, runtimeParams, ORG_DISCOVERY_PARAMETER);
+        } else if (request.getParameterMap().containsKey(ORG_DISCOVERY_PARAMETER)) {
+            // `orgDiscovery` request parameter is deprecated. `login_hint` should be used instead.
+            String discoveryInput = request.getParameter(ORG_DISCOVERY_PARAMETER);
             context.setProperty(ORG_DISCOVERY_PARAMETER, discoveryInput);
             if (!validateDiscoveryAttributeValue(discoveryInput, context, response)) {
                 context.removeProperty(ORG_DISCOVERY_PARAMETER);


### PR DESCRIPTION
## Purpose
Currently we are supporting the following parameters as request parameters for organization discovery.
- `orgId`
- `org`
- `login_hint`
- `orgDiscovery`
- `orgDiscoveryType`

With this PR, we give the support for those parameters as authenticator params in adaptive script.

Issue - https://github.com/wso2/product-is/issues/23848