### PR TITLE
Add org identifier handler to feature component and update friendly name

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.handler.organization.identifier/src/main/java/org/wso2/carbon/identity/application/authenticator/handler/organization/identifier/constant/OrganizationIdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.handler.organization.identifier/src/main/java/org/wso2/carbon/identity/application/authenticator/handler/organization/identifier/constant/OrganizationIdentifierHandlerConstants.java
@@ -29,7 +29,7 @@ public class OrganizationIdentifierHandlerConstants {
 
     public static final String AUTHENTICATOR_NAME = "OrganizationIdentifierHandler";
     public static final String AUTHENTICATOR_ORGANIZATION_IDENTIFIER = "authenticator.organization.identifier";
-    public static final String AUTHENTICATOR_FRIENDLY_NAME = "Organization SSO";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "SSO";
     public static final String CONTEXT_IDENTIFIER = "sessionDataKey";
 
     public static final String EQUAL_SIGN = "=";

--- a/components/org.wso2.carbon.identity.application.authenticator.handler.organization.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/organization/identifier/OrganizationIdentifierHandlerTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.handler.organization.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/organization/identifier/OrganizationIdentifierHandlerTest.java
@@ -165,7 +165,7 @@ public class OrganizationIdentifierHandlerTest {
     @Test
     public void testGetFriendlyName() {
 
-        Assert.assertEquals(organizationIdentifierHandler.getFriendlyName(), "Organization SSO");
+        Assert.assertEquals(organizationIdentifierHandler.getFriendlyName(), "SSO");
     }
 
     @Test
@@ -460,7 +460,7 @@ public class OrganizationIdentifierHandlerTest {
         AuthenticatorData data = result.get();
         Assert.assertEquals(data.getName(), "OrganizationIdentifierHandler");
         Assert.assertEquals(data.getI18nKey(), "authenticator.organization.identifier");
-        Assert.assertEquals(data.getDisplayName(), "Organization SSO");
+        Assert.assertEquals(data.getDisplayName(), "SSO");
         Assert.assertEquals(data.getPromptType(), FrameworkConstants.AuthenticatorPromptType.USER_PROMPT);
         Assert.assertEquals(data.getRequiredParams().size(), 5);
         Assert.assertEquals(data.getAuthParams().size(), 5);

--- a/features/org.wso2.carbon.identity.auth.organization.login.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.organization.login.server.feature/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
             <artifactId>org.wso2.carbon.identity.application.authenticator.organization.login</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -60,6 +64,7 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>org.wso2.carbon.identity.auth.organization.login:org.wso2.carbon.identity.application.authenticator.organization.login</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.auth.organization.login:org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.orbit.com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
                 <version>${nimbusds.version}</version>


### PR DESCRIPTION
## Purpose
>$Subject

Issue - https://github.com/wso2/product-is/issues/24364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the authenticator display name from "Organization SSO" to "SSO"
  * Added and configured organization authentication artifacts in project features and dependencies

* **Tests**
  * Adjusted unit tests to reflect the shortened display name ("SSO")
<!-- end of auto-generated comment: release notes by coderabbit.ai -->