### PR TITLE
Add Shared User Identifier Handler and related components.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
@@ -118,7 +118,6 @@
 
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
 
-                            org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
@@ -132,7 +131,8 @@
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal,
-                            org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.*;version="${project.version}"
+                            org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier;version="${project.version}",
+                            org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants;version="${project.version}"
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
         <artifactId>identity-auth-organization-login</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~  WSO2 LLC. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
+        <artifactId>identity-auth-organization-login</artifactId>
+        <version>1.2.5-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Shared User Identifier Auth Identity Application Authentication Handler</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal
+                        </Private-Package>
+                        <Import-Package>
+                            javax.servlet.http; version="${javax.servlet.imp.pkg.version.range}",
+
+                            org.apache.commons.logging; version="${org.apache.commons.logging.imp.pkg.version.range}",
+                            org.apache.commons.lang; version="${org.apache.commons.lang.imp.pkg.version.range}",
+
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+
+                            org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.base;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.utils; version="${carbon.identity.package.import.version.range}",
+
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+
+                            org.wso2.carbon.user.core; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.service; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.util; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.common; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils; version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.organization.management.service;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.exception;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal,
+                            org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.*;version="${project.version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
         <artifactId>identity-auth-organization-login</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -70,6 +70,22 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -120,6 +136,57 @@
                         </Export-Package>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.class</exclude>
+                        <exclude>org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorDataHolder.class</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-instrument</id>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
@@ -6,7 +6,7 @@
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing,
  *  software distributed under the License is distributed on an
@@ -40,7 +40,6 @@ import org.wso2.carbon.identity.application.authentication.handler.shared.user.i
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
@@ -171,9 +170,7 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
 
         AuthenticatedUser user = new AuthenticatedUser();
         String tenantDomain = context.getTenantDomain();
-        String userStoreDomain = IdentityUtil.extractDomainFromName(identifierFromRequest);
-        Optional<String> userId = resolveUserIdFromUserStore(tenantDomain, identifierFromRequest, userStoreDomain,
-                user);
+        Optional<String> userId = resolveUserIdFromUserStore(tenantDomain, identifierFromRequest, user);
         // To autopopulate username at later steps.
         persistUsername(context, identifierFromRequest);
 
@@ -202,12 +199,12 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
      * Resolves the user ID from the user store for the given tenant domain and username.
      *
      * @param tenantDomain        The tenant domain.
-     * @param tenantAwareUsername The tenant aware username.
-     * @return The resolved user ID.
+     * @param username            The username.
+     * @return                    The resolved user ID.
      * @throws AuthenticationFailedException If user resolution fails.
      */
-    private Optional<String> resolveUserIdFromUserStore(String tenantDomain, String tenantAwareUsername,
-                                                        String userStoreDomain, AuthenticatedUser user)
+    private Optional<String> resolveUserIdFromUserStore(String tenantDomain, String username,
+                                                        AuthenticatedUser user)
             throws AuthenticationFailedException {
 
         try {
@@ -222,9 +219,9 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
                 throw new AuthenticationFailedException(
                         ErrorMessages.CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT.getCode(),
                         String.format(ErrorMessages.CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT.getMessage(),
-                                tenantId), User.getUserFromUserName(tenantAwareUsername));
+                                tenantId), User.getUserFromUserName(username));
             }
-            String userId = searchUserInUserStores(tenantAwareUsername, userRealm, userStoreDomain, user);
+            String userId = searchUserInUserStores(username, userRealm, user);
             if (userId == null) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("User does not exist in tenant: " + tenantDomain);
@@ -240,7 +237,7 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
 
             throw new AuthenticationFailedException(
                     ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getCode(),
-                    e.getMessage(), User.getUserFromUserName(tenantAwareUsername), e);
+                    e.getMessage(), User.getUserFromUserName(username), e);
         }
     }
 
@@ -250,19 +247,14 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
      * primary user store and all secondary user stores are iterated until the user is located.
      * When the user is found, the matched user store domain is set on the {@link AuthenticatedUser} object.
      *
-     * @param username        The tenant-aware username to search for.
+     * @param username        The username to search for.
      * @param userRealm       The user realm of the tenant.
-     * @param userStoreDomain The user store domain to scope the search, or blank to search all stores.
      * @param user            The authenticated user object to update with the resolved user store domain.
      * @return The user ID if the user is found, or {@code null} if the user does not exist in any user store.
      * @throws UserStoreException If an error occurs while accessing the user store.
      */
-    private static String searchUserInUserStores(String username, UserRealm userRealm, String userStoreDomain,
-                                                 AuthenticatedUser user) throws UserStoreException {
-
-        if (StringUtils.isNotBlank(userStoreDomain)) {
-            username = UserCoreUtil.addDomainToName(username, userStoreDomain);
-        }
+    private static String searchUserInUserStores(String username, UserRealm userRealm, AuthenticatedUser user)
+            throws UserStoreException {
 
         AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) userRealm.getUserStoreManager();
         String userId = userStoreManager.getUserIDFromUserName(username);

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.organization.management.service.exception.Organi
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.DiagnosticLog;
 
 import java.io.IOException;
@@ -169,9 +170,11 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
         }
         context.setProperty(USERNAME_USER_INPUT, identifierFromRequest);
 
+        AuthenticatedUser user = new AuthenticatedUser();
         String tenantDomain = context.getTenantDomain();
         String userStoreDomain = IdentityUtil.extractDomainFromName(identifierFromRequest);
-        Optional<String> userId = resolveUserIdFromUserStore(tenantDomain, identifierFromRequest);
+        Optional<String> userId = resolveUserIdFromUserStore(tenantDomain, identifierFromRequest, userStoreDomain,
+                user);
         // To autopopulate username at later steps.
         persistUsername(context, identifierFromRequest);
 
@@ -179,14 +182,13 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
             /* User does not exist in the accessing organization.
              * Skip shared user resolution and pass the flow to the next step.
              */
-            AuthenticatedUser user = new AuthenticatedUser();
             user.setUserName(identifierFromRequest);
             context.setSubject(user);
             return;
         }
 
         // Check if the user is a shared user using OrganizationUserSharingService.
-        resolveSharedUser(userId.get(), tenantDomain, identifierFromRequest, userStoreDomain, context);
+        resolveSharedUser(userId.get(), tenantDomain, identifierFromRequest, user, context);
         if (LoggerUtils.isDiagnosticLogsEnabled() && authProcessCompletedDiagnosticLogBuilder != null) {
             authProcessCompletedDiagnosticLogBuilder
                     .resultMessage("Shared user identifier first authentication successful.")
@@ -205,7 +207,8 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
      * @return The resolved user ID.
      * @throws AuthenticationFailedException If user resolution fails.
      */
-    private Optional<String> resolveUserIdFromUserStore(String tenantDomain, String tenantAwareUsername)
+    private Optional<String> resolveUserIdFromUserStore(String tenantDomain, String tenantAwareUsername,
+                                                        String userStoreDomain, AuthenticatedUser user)
             throws AuthenticationFailedException {
 
         try {
@@ -222,9 +225,7 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
                         String.format(ErrorMessages.CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT.getMessage(),
                                 tenantId), User.getUserFromUserName(tenantAwareUsername));
             }
-
-            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) userRealm.getUserStoreManager();
-            String userId = userStoreManager.getUserIDFromUserName(tenantAwareUsername);
+            String userId = searchUserInUserStores(tenantAwareUsername, userRealm, userStoreDomain, user);
             if (userId == null) {
                 if (log.isDebugEnabled()) {
                     log.debug("User does not exist in tenant: " + tenantDomain);
@@ -245,23 +246,54 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
     }
 
     /**
+     * Searches for a user across user stores within the given user realm and returns the user ID if found.
+     * If a specific user store domain is provided, the search is scoped to that domain; otherwise, the
+     * primary user store and all secondary user stores are iterated until the user is located.
+     * When the user is found, the matched user store domain is set on the {@link AuthenticatedUser} object.
+     *
+     * @param username        The tenant-aware username to search for.
+     * @param userRealm       The user realm of the tenant.
+     * @param userStoreDomain The user store domain to scope the search, or blank to search all stores.
+     * @param user            The authenticated user object to update with the resolved user store domain.
+     * @return The user ID if the user is found, or {@code null} if the user does not exist in any user store.
+     * @throws UserStoreException If an error occurs while accessing the user store.
+     */
+    private static String searchUserInUserStores(String username, UserRealm userRealm, String userStoreDomain,
+                                                 AuthenticatedUser user) throws UserStoreException {
+
+        if (StringUtils.isNotBlank(userStoreDomain)) {
+            username = UserCoreUtil.addDomainToName(username, userStoreDomain);
+        }
+
+        AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) userRealm.getUserStoreManager();
+        String userId = userStoreManager.getUserIDFromUserName(username);
+
+        while (userId == null && userStoreManager.getSecondaryUserStoreManager() != null) {
+            userStoreManager = (AbstractUserStoreManager) userStoreManager.getSecondaryUserStoreManager();
+            userId = userStoreManager.getUserIDFromUserName(username);
+        }
+
+        if (userId != null) {
+            user.setUserStoreDomain(UserCoreUtil.getDomainName(userStoreManager.getRealmConfiguration()));
+        }
+
+        return userId;
+    }
+
+    /**
      * Validates whether the given user is a shared user in the current tenant by checking
      * the user association using the {@link OrganizationUserSharingService}.
      *
      * @param userId          The user ID.
      * @param tenantDomain    The tenant domain.
      * @param username        The full username (used for error context).
-     * @param userStoreDomain The user store domain.
      * @param context         The authentication context.
      * @throws AuthenticationFailedException If the user is not a shared user or an error occurs.
      */
-    private void resolveSharedUser(String userId, String tenantDomain, String username, String userStoreDomain,
+    private void resolveSharedUser(String userId, String tenantDomain, String username, AuthenticatedUser user,
                                    AuthenticationContext context) throws AuthenticationFailedException {
 
-        AuthenticatedUser user = new AuthenticatedUser();
         user.setUserName(username);
-        user.setUserStoreDomain(userStoreDomain);
-
         try {
             OrganizationManager organizationManager = SharedUserIdentifierAuthenticatorDataHolder
                     .getInstance().getOrganizationManager();

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticationFlowHandler;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorParamMetadata;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants;
+import org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal.SharedUserIdentifierAuthenticatorDataHolder;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.central.log.mgt.utils.LogConstants;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.utils.DiagnosticLog;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.DISPLAY_USER_NAME;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.ErrorMessages;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.LogConstants.ActionIDs.AUTHENTICATOR_SHARED_USER_IDENTIFIER;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.LogConstants.ActionIDs.INITIATE_SHARED_USER_IDENTIFIER_AUTH_REQUEST;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.LogConstants.ActionIDs.PROCESS_AUTHENTICATION_RESPONSE;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.LogConstants.SHARED_USER_IDENTIFIER_AUTH_SERVICE;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.USERNAME_USER_INPUT;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.USER_NAME;
+
+/**
+ * Shared user identifier based handler.
+ * <p>
+ * This handler is responsible for taking a user identifier input and checking if the user is a shared user
+ * in the accessing organization. It extends {@link AbstractApplicationAuthenticator} and implements
+ * {@link AuthenticationFlowHandler}.
+ * </p>
+ */
+public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticator
+        implements AuthenticationFlowHandler {
+
+    private static final Log log = LogFactory.getLog(SharedUserIdentifierHandler.class);
+
+    @Override
+    public boolean canHandle(HttpServletRequest request) {
+
+        String userName = request.getParameter(USER_NAME);
+        boolean canHandle = StringUtils.isNotBlank(userName);
+        if (LoggerUtils.isDiagnosticLogsEnabled() && canHandle) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    SHARED_USER_IDENTIFIER_AUTH_SERVICE,
+                    FrameworkConstants.LogConstants.ActionIDs.HANDLE_AUTH_STEP);
+            diagnosticLogBuilder.resultMessage("Shared User Identifier Handler is handling the request.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.INTERNAL_SYSTEM)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS);
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
+        return canHandle;
+    }
+
+    @Override
+    public AuthenticatorFlowStatus process(HttpServletRequest request,
+                                           HttpServletResponse response, AuthenticationContext context)
+            throws AuthenticationFailedException, LogoutFailedException {
+
+        if (context.isLogoutRequest()) {
+            return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
+        }
+        return super.process(request, response, context);
+    }
+
+    @Override
+    @SuppressFBWarnings(value = "UNVALIDATED_REDIRECT", justification = "Redirect params are not based on user inputs.")
+    protected void initiateAuthenticationRequest(HttpServletRequest request,
+                                                 HttpServletResponse response, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    SHARED_USER_IDENTIFIER_AUTH_SERVICE, INITIATE_SHARED_USER_IDENTIFIER_AUTH_REQUEST);
+            diagnosticLogBuilder.resultMessage("Initiating shared user identifier first authentication request.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+        }
+
+        try {
+            response.sendRedirect(buildRedirectURL(context));
+        } catch (IOException e) {
+            if (log.isDebugEnabled()) {
+                log.debug(getName() + " failed while initiating the authentication request.", e);
+            }
+            throw new AuthenticationFailedException(ErrorMessages.SYSTEM_ERROR_WHILE_AUTHENTICATING.getCode(),
+                    e.getMessage(), User.getUserFromUserName(request.getParameter(USER_NAME)), e);
+        }
+    }
+
+    @Override
+    protected void processAuthenticationResponse(HttpServletRequest request,
+                                                 HttpServletResponse response, AuthenticationContext context)
+            throws AuthenticationFailedException {
+
+        DiagnosticLog.DiagnosticLogBuilder authProcessCompletedDiagnosticLogBuilder = null;
+        if (LoggerUtils.isDiagnosticLogsEnabled()) {
+            DiagnosticLog.DiagnosticLogBuilder diagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    SHARED_USER_IDENTIFIER_AUTH_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+            diagnosticLogBuilder.resultMessage("Processing shared user identifier first authentication response.")
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep())
+                    .inputParams(getApplicationDetails(context));
+            LoggerUtils.triggerDiagnosticLogEvent(diagnosticLogBuilder);
+
+            authProcessCompletedDiagnosticLogBuilder = new DiagnosticLog.DiagnosticLogBuilder(
+                    SHARED_USER_IDENTIFIER_AUTH_SERVICE, PROCESS_AUTHENTICATION_RESPONSE);
+            authProcessCompletedDiagnosticLogBuilder.inputParams(getApplicationDetails(context))
+                    .logDetailLevel(DiagnosticLog.LogDetailLevel.APPLICATION)
+                    .resultStatus(DiagnosticLog.ResultStatus.SUCCESS)
+                    .inputParam(LogConstants.InputKeys.STEP, context.getCurrentStep());
+        }
+
+        String identifierFromRequest = request.getParameter(USER_NAME);
+        if (StringUtils.isBlank(identifierFromRequest)) {
+            throw new InvalidCredentialsException(ErrorMessages.EMPTY_USERNAME.getCode(),
+                    ErrorMessages.EMPTY_USERNAME.getMessage());
+        }
+        context.setProperty(USERNAME_USER_INPUT, identifierFromRequest);
+
+        String tenantDomain = context.getTenantDomain();
+        String userStoreDomain = IdentityUtil.extractDomainFromName(identifierFromRequest);
+        Optional<String> userId = resolveUserIdFromUserStore(tenantDomain, identifierFromRequest);
+        // To autopopulate username at later steps.
+        persistUsername(context, identifierFromRequest);
+
+        if (userId.isEmpty()) {
+            /* User does not exist in the accessing organization.
+             * Skip shared user resolution and pass the flow to the next step.
+             */
+            AuthenticatedUser user = new AuthenticatedUser();
+            user.setUserName(identifierFromRequest);
+            context.setSubject(user);
+            return;
+        }
+
+        // Check if the user is a shared user using OrganizationUserSharingService.
+        resolveSharedUser(userId.get(), tenantDomain, identifierFromRequest, userStoreDomain, context);
+        if (LoggerUtils.isDiagnosticLogsEnabled() && authProcessCompletedDiagnosticLogBuilder != null) {
+            authProcessCompletedDiagnosticLogBuilder
+                    .resultMessage("Shared user identifier first authentication successful.")
+                    .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable
+                            ? LoggerUtils.getMaskedContent(identifierFromRequest) : identifierFromRequest)
+                    .inputParam(LogConstants.InputKeys.USER_ID, userId);
+            LoggerUtils.triggerDiagnosticLogEvent(authProcessCompletedDiagnosticLogBuilder);
+        }
+    }
+
+    /**
+     * Resolves the user ID from the user store for the given tenant domain and username.
+     *
+     * @param tenantDomain        The tenant domain.
+     * @param tenantAwareUsername The tenant aware username.
+     * @return The resolved user ID.
+     * @throws AuthenticationFailedException If user resolution fails.
+     */
+    private Optional<String> resolveUserIdFromUserStore(String tenantDomain, String tenantAwareUsername)
+            throws AuthenticationFailedException {
+
+        try {
+            int tenantId = SharedUserIdentifierAuthenticatorDataHolder
+                    .getInstance().getRealmService().getTenantManager().getTenantId(tenantDomain);
+            UserRealm userRealm = SharedUserIdentifierAuthenticatorDataHolder.getInstance().getRealmService()
+                    .getTenantUserRealm(tenantId);
+            if (userRealm == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Cannot find the user realm for the tenant ID: " + tenantId);
+                }
+                throw new AuthenticationFailedException(
+                        ErrorMessages.CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT.getCode(),
+                        String.format(ErrorMessages.CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT.getMessage(),
+                                tenantId), User.getUserFromUserName(tenantAwareUsername));
+            }
+
+            AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) userRealm.getUserStoreManager();
+            String userId = userStoreManager.getUserIDFromUserName(tenantAwareUsername);
+            if (userId == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("User does not exist in tenant: " + tenantDomain);
+                }
+                return Optional.empty();
+            }
+
+            return Optional.of(userId);
+        } catch (UserStoreException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("SharedUserIdentifierHandler failed while trying to authenticate.", e);
+            }
+
+            throw new AuthenticationFailedException(
+                    ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getCode(),
+                    e.getMessage(), User.getUserFromUserName(tenantAwareUsername), e);
+        }
+    }
+
+    /**
+     * Validates whether the given user is a shared user in the current tenant by checking
+     * the user association using the {@link OrganizationUserSharingService}.
+     *
+     * @param userId          The user ID.
+     * @param tenantDomain    The tenant domain.
+     * @param username        The full username (used for error context).
+     * @param userStoreDomain The user store domain.
+     * @param context         The authentication context.
+     * @throws AuthenticationFailedException If the user is not a shared user or an error occurs.
+     */
+    private void resolveSharedUser(String userId, String tenantDomain, String username, String userStoreDomain,
+                                   AuthenticationContext context) throws AuthenticationFailedException {
+
+        AuthenticatedUser user = new AuthenticatedUser();
+        user.setUserName(username);
+        user.setUserStoreDomain(userStoreDomain);
+
+        try {
+            OrganizationManager organizationManager = SharedUserIdentifierAuthenticatorDataHolder
+                    .getInstance().getOrganizationManager();
+            String organizationId = organizationManager.resolveOrganizationId(tenantDomain);
+            if (StringUtils.isBlank(organizationId)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Unable to resolve organization ID for tenant: " + tenantDomain);
+                }
+                throw new AuthenticationFailedException(ErrorMessages.ORGANIZATION_MGT_EXCEPTION.getCode(),
+                        "Unable to resolve organization ID for tenant: " + tenantDomain,
+                        User.getUserFromUserName(username));
+            }
+
+            OrganizationUserSharingService userSharingService = SharedUserIdentifierAuthenticatorDataHolder
+                    .getInstance().getOrganizationUserSharingService();
+            UserAssociation userAssociation = userSharingService.getUserAssociation(userId, organizationId);
+            if (userAssociation != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("User with ID: " + userId + " is confirmed as a shared user in organization: "
+                            + organizationId + " (associated user ID: " + userAssociation.getAssociatedUserId()
+                            + ", resident org: " + userAssociation.getUserResidentOrganizationId() + ")");
+                }
+
+                user.setUserResidentOrganization(userAssociation.getUserResidentOrganizationId());
+                user.setAccessingOrganization(organizationManager.resolveOrganizationId(context.getTenantDomain()));
+                user.setTenantDomain(organizationManager.resolveTenantDomain(
+                        userAssociation.getUserResidentOrganizationId()));
+                user.setSharedUser(true);
+            }
+
+            context.setSubject(user);
+        } catch (OrganizationManagementException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("SharedUserIdentifierHandler failed while checking shared user status.", e);
+            }
+            throw new AuthenticationFailedException(ErrorMessages.ORGANIZATION_MGT_EXCEPTION.getCode(),
+                    e.getMessage(), User.getUserFromUserName(username), e);
+        }
+    }
+
+    @Override
+    protected boolean retryAuthenticationEnabled() {
+
+        return true;
+    }
+
+    @Override
+    public String getContextIdentifier(HttpServletRequest request) {
+
+        return request.getParameter(FrameworkConstants.SESSION_DATA_KEY);
+    }
+
+    @Override
+    public String getFriendlyName() {
+
+        return SharedUserIdentifierHandlerConstants.HANDLER_FRIENDLY_NAME;
+    }
+
+    @Override
+    public String getName() {
+
+        return SharedUserIdentifierHandlerConstants.HANDLER_NAME;
+    }
+
+    private void persistUsername(AuthenticationContext context, String username) {
+
+        Map<String, String> identifierParams = new HashMap<>();
+        identifierParams.put(FrameworkConstants.JSAttributes.JS_OPTIONS_USERNAME, username);
+        Map<String, Map<String, String>> contextParams = new HashMap<>();
+        contextParams.put(FrameworkConstants.JSAttributes.JS_COMMON_OPTIONS, identifierParams);
+        context.addAuthenticatorParams(contextParams);
+    }
+
+    /**
+     * Build the redirect URL for the authentication request.
+     *
+     * @param context The authentication context.
+     * @return The redirect URL.
+     */
+    private String buildRedirectURL(AuthenticationContext context) {
+
+        String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
+        String queryParams = context.getContextIdIncludedQueryParams();
+
+        StringBuilder queryStringBuilder = new StringBuilder(queryParams);
+        queryStringBuilder.append(SharedUserIdentifierHandlerConstants.AMPERSAND_SIGN)
+                .append(SharedUserIdentifierHandlerConstants.AUTHENTICATORS_PARAM)
+                .append(SharedUserIdentifierHandlerConstants.EQUAL_SIGN)
+                .append(getName())
+                .append(SharedUserIdentifierHandlerConstants.COLON_SIGN)
+                .append(SharedUserIdentifierHandlerConstants.LOCAL);
+
+        if (context.isRetrying()) {
+            queryStringBuilder.append(SharedUserIdentifierHandlerConstants.AMPERSAND_SIGN)
+                    .append(SharedUserIdentifierHandlerConstants.AUTH_FAILURE)
+                    .append(SharedUserIdentifierHandlerConstants.EQUAL_SIGN)
+                    .append(SharedUserIdentifierHandlerConstants.TRUE)
+                    .append(SharedUserIdentifierHandlerConstants.AMPERSAND_SIGN)
+                    .append(SharedUserIdentifierHandlerConstants.AUTH_FAILURE_MSG)
+                    .append(SharedUserIdentifierHandlerConstants.EQUAL_SIGN)
+                    .append(SharedUserIdentifierHandlerConstants.LOGIN_FAILED_GENERIC);
+        }
+
+        return FrameworkUtils.appendQueryParamsStringToUrl(loginPage, queryStringBuilder.toString());
+    }
+
+    /**
+     * Add application details to a map.
+     *
+     * @param context AuthenticationContext.
+     * @return Map with application details.
+     */
+    private Map<String, String> getApplicationDetails(AuthenticationContext context) {
+
+        Map<String, String> applicationDetailsMap = new HashMap<>();
+        FrameworkUtils.getApplicationResourceId(context).ifPresent(applicationId ->
+                applicationDetailsMap.put(LogConstants.InputKeys.APPLICATION_ID, applicationId));
+        FrameworkUtils.getApplicationName(context).ifPresent(applicationName ->
+                applicationDetailsMap.put(LogConstants.InputKeys.APPLICATION_NAME, applicationName));
+        return applicationDetailsMap;
+    }
+
+    @Override
+    public boolean isAPIBasedAuthenticationSupported() {
+
+        return true;
+    }
+
+    @Override
+    public Optional<AuthenticatorData> getAuthInitiationData(AuthenticationContext context) {
+
+        String idpName = null;
+        if (context != null && context.getExternalIdP() != null) {
+            idpName = context.getExternalIdP().getIdPName();
+        }
+
+        AuthenticatorData authenticatorData = new AuthenticatorData();
+        authenticatorData.setName(getName());
+        authenticatorData.setIdp(idpName);
+        authenticatorData.setI18nKey(getI18nKey());
+        authenticatorData.setDisplayName(getFriendlyName());
+        authenticatorData.setPromptType(FrameworkConstants.AuthenticatorPromptType.USER_PROMPT);
+
+        List<String> requiredParams = new ArrayList<>();
+        requiredParams.add(USER_NAME);
+        authenticatorData.setRequiredParams(requiredParams);
+
+        List<AuthenticatorParamMetadata> authenticatorParamMetadataList = new ArrayList<>();
+        AuthenticatorParamMetadata usernameMetadata = new AuthenticatorParamMetadata(
+                USER_NAME, DISPLAY_USER_NAME, FrameworkConstants.AuthenticatorParamType.STRING,
+                0, Boolean.FALSE, USER_NAME);
+        authenticatorParamMetadataList.add(usernameMetadata);
+        authenticatorData.setAuthParams(authenticatorParamMetadataList);
+
+        return Optional.of(authenticatorData);
+    }
+
+    @Override
+    public String getI18nKey() {
+
+        return AUTHENTICATOR_SHARED_USER_IDENTIFIER;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandler.java
@@ -81,7 +81,7 @@ import static org.wso2.carbon.identity.application.authentication.handler.shared
 public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticator
         implements AuthenticationFlowHandler {
 
-    private static final Log log = LogFactory.getLog(SharedUserIdentifierHandler.class);
+    private static final Log LOG = LogFactory.getLog(SharedUserIdentifierHandler.class);
 
     @Override
     public boolean canHandle(HttpServletRequest request) {
@@ -131,11 +131,10 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
         try {
             response.sendRedirect(buildRedirectURL(context));
         } catch (IOException e) {
-            if (log.isDebugEnabled()) {
-                log.debug(getName() + " failed while initiating the authentication request.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(getName() + " failed while initiating the authentication request.", e);
             }
-            throw new AuthenticationFailedException(ErrorMessages.SYSTEM_ERROR_WHILE_AUTHENTICATING.getCode(),
-                    e.getMessage(), User.getUserFromUserName(request.getParameter(USER_NAME)), e);
+            throw new AuthenticationFailedException(ErrorMessages.SYSTEM_ERROR_WHILE_AUTHENTICATING.getMessage(), e);
         }
     }
 
@@ -194,7 +193,7 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
                     .resultMessage("Shared user identifier first authentication successful.")
                     .inputParam(LogConstants.InputKeys.USER, LoggerUtils.isLogMaskingEnable
                             ? LoggerUtils.getMaskedContent(identifierFromRequest) : identifierFromRequest)
-                    .inputParam(LogConstants.InputKeys.USER_ID, userId);
+                    .inputParam(LogConstants.InputKeys.USER_ID, userId.get());
             LoggerUtils.triggerDiagnosticLogEvent(authProcessCompletedDiagnosticLogBuilder);
         }
     }
@@ -217,8 +216,8 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
             UserRealm userRealm = SharedUserIdentifierAuthenticatorDataHolder.getInstance().getRealmService()
                     .getTenantUserRealm(tenantId);
             if (userRealm == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Cannot find the user realm for the tenant ID: " + tenantId);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Cannot find the user realm for the tenant ID: " + tenantId);
                 }
                 throw new AuthenticationFailedException(
                         ErrorMessages.CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT.getCode(),
@@ -227,16 +226,16 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
             }
             String userId = searchUserInUserStores(tenantAwareUsername, userRealm, userStoreDomain, user);
             if (userId == null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("User does not exist in tenant: " + tenantDomain);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("User does not exist in tenant: " + tenantDomain);
                 }
                 return Optional.empty();
             }
 
             return Optional.of(userId);
         } catch (UserStoreException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("SharedUserIdentifierHandler failed while trying to authenticate.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("SharedUserIdentifierHandler failed while trying to authenticate.", e);
             }
 
             throw new AuthenticationFailedException(
@@ -288,7 +287,7 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
      * @param tenantDomain    The tenant domain.
      * @param username        The full username (used for error context).
      * @param context         The authentication context.
-     * @throws AuthenticationFailedException If the user is not a shared user or an error occurs.
+     * @throws AuthenticationFailedException If an error occurs while resolving the shared user.
      */
     private void resolveSharedUser(String userId, String tenantDomain, String username, AuthenticatedUser user,
                                    AuthenticationContext context) throws AuthenticationFailedException {
@@ -298,36 +297,33 @@ public class SharedUserIdentifierHandler extends AbstractApplicationAuthenticato
             OrganizationManager organizationManager = SharedUserIdentifierAuthenticatorDataHolder
                     .getInstance().getOrganizationManager();
             String organizationId = organizationManager.resolveOrganizationId(tenantDomain);
-            if (StringUtils.isBlank(organizationId)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Unable to resolve organization ID for tenant: " + tenantDomain);
-                }
-                throw new AuthenticationFailedException(ErrorMessages.ORGANIZATION_MGT_EXCEPTION.getCode(),
-                        "Unable to resolve organization ID for tenant: " + tenantDomain,
-                        User.getUserFromUserName(username));
-            }
-
             OrganizationUserSharingService userSharingService = SharedUserIdentifierAuthenticatorDataHolder
                     .getInstance().getOrganizationUserSharingService();
             UserAssociation userAssociation = userSharingService.getUserAssociation(userId, organizationId);
             if (userAssociation != null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("User with ID: " + userId + " is confirmed as a shared user in organization: "
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("User with ID: " + userId + " is confirmed as a shared user in organization: "
                             + organizationId + " (associated user ID: " + userAssociation.getAssociatedUserId()
                             + ", resident org: " + userAssociation.getUserResidentOrganizationId() + ")");
                 }
 
+                /*
+                 * If the user is confirmed as a shared user, update the authenticated user to reflect that they are
+                 * accessing a sub-organization. The authenticated user is treated as a shared user in the framework
+                 * only when these properties are set by this handler.
+                 */
                 user.setUserResidentOrganization(userAssociation.getUserResidentOrganizationId());
                 user.setAccessingOrganization(organizationManager.resolveOrganizationId(context.getTenantDomain()));
                 user.setTenantDomain(organizationManager.resolveTenantDomain(
                         userAssociation.getUserResidentOrganizationId()));
+                user.setSharedUserId(userId);
                 user.setSharedUser(true);
             }
 
             context.setSubject(user);
         } catch (OrganizationManagementException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("SharedUserIdentifierHandler failed while checking shared user status.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("SharedUserIdentifierHandler failed while checking shared user status.", e);
             }
             throw new AuthenticationFailedException(ErrorMessages.ORGANIZATION_MGT_EXCEPTION.getCode(),
                     e.getMessage(), User.getUserFromUserName(username), e);

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/constants/SharedUserIdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/constants/SharedUserIdentifierHandlerConstants.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants;
+
+/**
+ * Constants used by the SharedUserIdentifierHandler.
+ */
+public abstract class SharedUserIdentifierHandlerConstants {
+
+    public static final String HANDLER_NAME = "SharedUserIdentifierExecutor";
+    public static final String HANDLER_FRIENDLY_NAME = "Shared User Identifier";
+    public static final String USER_NAME = "username";
+    public static final String DISPLAY_USER_NAME = "Username";
+    public static final String AUTHENTICATORS_PARAM = "authenticators";
+    public static final String LOCAL = "LOCAL";
+    public static final String USERNAME_USER_INPUT = "usernameUserInput";
+    public static final String AMPERSAND_SIGN = "&";
+    public static final String EQUAL_SIGN = "=";
+    public static final String COLON_SIGN = ":";
+    public static final String AUTH_FAILURE = "authFailure";
+    public static final String AUTH_FAILURE_MSG = "authFailureMsg";
+    public static final String LOGIN_FAILED_GENERIC = "login.failed.generic";
+    public static final String TRUE = "true";
+
+    private SharedUserIdentifierHandlerConstants() {
+
+    }
+
+    /**
+     * Constants related to log management.
+     */
+    public static class LogConstants {
+
+        public static final String SHARED_USER_IDENTIFIER_AUTH_SERVICE = "local-auth-shared-user-identifier-handler";
+
+        /**
+         * Define action IDs for diagnostic logs.
+         */
+        public static class ActionIDs {
+
+            public static final String PROCESS_AUTHENTICATION_RESPONSE =
+                    "process-shared-user-identifier-authentication-response";
+            public static final String INITIATE_SHARED_USER_IDENTIFIER_AUTH_REQUEST =
+                    "initiate-shared-user-identifier-authentication-request";
+            public static final String AUTHENTICATOR_SHARED_USER_IDENTIFIER =
+                    "authenticator.shared-user-identifier";
+        }
+    }
+
+    /**
+     * Error messages used by the SharedUserIdentifierHandler.
+     */
+    public enum ErrorMessages {
+
+        EMPTY_USERNAME("SUIH-60001", "Username is empty."),
+        SYSTEM_ERROR_WHILE_AUTHENTICATING("SUIH-65001", "System error while authenticating."),
+        CANNOT_FIND_THE_USER_REALM_FOR_THE_GIVEN_TENANT("SUIH-65002",
+                "Cannot find the user realm for the given tenant: %s"),
+        USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE("SUIH-65003",
+                "UserStoreException while trying to authenticate."),
+        ORGANIZATION_MGT_EXCEPTION("SUIH-65005",
+                "Organization management exception while resolving shared user.");
+
+        private final String code;
+        private final String message;
+
+        ErrorMessages(String code, String message) {
+
+            this.code = code;
+            this.message = message;
+        }
+
+        public String getCode() {
+
+            return code;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        @Override
+        public String toString() {
+
+            return code + " - " + message;
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/constants/SharedUserIdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/constants/SharedUserIdentifierHandlerConstants.java
@@ -6,7 +6,7 @@
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing,
  *  software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorDataHolder.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal;
+
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Data holder for Shared User Identifier Handler.
+ */
+public class SharedUserIdentifierAuthenticatorDataHolder {
+
+    private static final SharedUserIdentifierAuthenticatorDataHolder instance =
+            new SharedUserIdentifierAuthenticatorDataHolder();
+
+    private RealmService realmService;
+    private OrganizationUserSharingService organizationUserSharingService;
+    private OrganizationManager organizationManager;
+
+    private SharedUserIdentifierAuthenticatorDataHolder() {
+
+    }
+
+    /**
+     * Get the singleton instance of SharedUserIdentifierAuthenticatorDataHolder.
+     *
+     * @return SharedUserIdentifierAuthenticatorDataHolder instance.
+     */
+    public static SharedUserIdentifierAuthenticatorDataHolder getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * Get the Realm Service.
+     *
+     * @return RealmService instance.
+     */
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    /**
+     * Set the Realm Service.
+     *
+     * @param realmService RealmService instance.
+     */
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+
+    /**
+     * Get the Organization User Sharing Service.
+     *
+     * @return OrganizationUserSharingService instance.
+     */
+    public OrganizationUserSharingService getOrganizationUserSharingService() {
+
+        return organizationUserSharingService;
+    }
+
+    /**
+     * Set the Organization User Sharing Service.
+     *
+     * @param organizationUserSharingService OrganizationUserSharingService instance.
+     */
+    public void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
+
+        this.organizationUserSharingService = organizationUserSharingService;
+    }
+
+    /**
+     * Get the Organization Manager.
+     *
+     * @return OrganizationManager instance.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Set the Organization Manager.
+     *
+     * @param organizationManager OrganizationManager instance.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorDataHolder.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.user.core.service.RealmService;
  */
 public class SharedUserIdentifierAuthenticatorDataHolder {
 
-    private static final SharedUserIdentifierAuthenticatorDataHolder instance =
+    private static final SharedUserIdentifierAuthenticatorDataHolder INSTANCE =
             new SharedUserIdentifierAuthenticatorDataHolder();
 
     private RealmService realmService;
@@ -45,7 +45,7 @@ public class SharedUserIdentifierAuthenticatorDataHolder {
      */
     public static SharedUserIdentifierAuthenticatorDataHolder getInstance() {
 
-        return instance;
+        return INSTANCE;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.SharedUserIdentifierHandler;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * OSGi declarative services component which handles registration and de-registration of
+ * SharedUserIdentifierHandler.
+ */
+@Component(
+        name = "identity.application.handler.shared.user.identifier.component",
+        immediate = true
+)
+public class SharedUserIdentifierAuthenticatorServiceComponent {
+
+    private static final Log log = LogFactory.getLog(SharedUserIdentifierAuthenticatorServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext ctxt) {
+
+        try {
+            SharedUserIdentifierHandler sharedUserIdentifierHandler = new SharedUserIdentifierHandler();
+            ctxt.getBundleContext().registerService(ApplicationAuthenticator.class.getName(),
+                    sharedUserIdentifierHandler, null);
+
+            if (log.isDebugEnabled()) {
+                log.info("SharedUserIdentifierHandler bundle is activated");
+            }
+        } catch (Throwable e) {
+            log.error("SharedUserIdentifierHandler bundle activation Failed", e);
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext ctxt) {
+
+        if (log.isDebugEnabled()) {
+            log.info("SharedUserIdentifierHandler bundle is deactivated");
+        }
+    }
+
+    @Reference(
+            name = "realm.service",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService"
+    )
+    protected void setRealmService(RealmService realmService) {
+
+        log.debug("Setting the Realm Service");
+        SharedUserIdentifierAuthenticatorDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        log.debug("Unsetting the Realm Service");
+        SharedUserIdentifierAuthenticatorDataHolder.getInstance().setRealmService(null);
+    }
+
+    @Reference(
+            name = "organization.user.sharing.service",
+            service = OrganizationUserSharingService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationUserSharingService"
+    )
+    protected void setOrganizationUserSharingService(
+            OrganizationUserSharingService organizationUserSharingService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the organization user sharing service.");
+        }
+        SharedUserIdentifierAuthenticatorDataHolder.getInstance()
+                .setOrganizationUserSharingService(organizationUserSharingService);
+    }
+
+    protected void unsetOrganizationUserSharingService(
+            OrganizationUserSharingService organizationUserSharingService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting the organization user sharing service.");
+        }
+        SharedUserIdentifierAuthenticatorDataHolder.getInstance().setOrganizationUserSharingService(null);
+    }
+
+    @Reference(
+            name = "organization.manager",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager"
+    )
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the organization manager service.");
+        }
+        SharedUserIdentifierAuthenticatorDataHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting the organization manager service.");
+        }
+        SharedUserIdentifierAuthenticatorDataHolder.getInstance().setOrganizationManager(null);
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.java
@@ -6,7 +6,7 @@
  *  in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing,
  *  software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/internal/SharedUserIdentifierAuthenticatorServiceComponent.java
@@ -43,7 +43,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 )
 public class SharedUserIdentifierAuthenticatorServiceComponent {
 
-    private static final Log log = LogFactory.getLog(SharedUserIdentifierAuthenticatorServiceComponent.class);
+    private static final Log LOG = LogFactory.getLog(SharedUserIdentifierAuthenticatorServiceComponent.class);
 
     @Activate
     protected void activate(ComponentContext ctxt) {
@@ -52,21 +52,16 @@ public class SharedUserIdentifierAuthenticatorServiceComponent {
             SharedUserIdentifierHandler sharedUserIdentifierHandler = new SharedUserIdentifierHandler();
             ctxt.getBundleContext().registerService(ApplicationAuthenticator.class.getName(),
                     sharedUserIdentifierHandler, null);
-
-            if (log.isDebugEnabled()) {
-                log.info("SharedUserIdentifierHandler bundle is activated");
-            }
+            LOG.debug("SharedUserIdentifierHandler bundle is activated");
         } catch (Throwable e) {
-            log.error("SharedUserIdentifierHandler bundle activation Failed", e);
+            LOG.error("SharedUserIdentifierHandler bundle activation Failed", e);
         }
     }
 
     @Deactivate
     protected void deactivate(ComponentContext ctxt) {
 
-        if (log.isDebugEnabled()) {
-            log.info("SharedUserIdentifierHandler bundle is deactivated");
-        }
+        LOG.debug("SharedUserIdentifierHandler bundle is deactivated");
     }
 
     @Reference(
@@ -78,13 +73,13 @@ public class SharedUserIdentifierAuthenticatorServiceComponent {
     )
     protected void setRealmService(RealmService realmService) {
 
-        log.debug("Setting the Realm Service");
+        LOG.debug("Setting the Realm Service");
         SharedUserIdentifierAuthenticatorDataHolder.getInstance().setRealmService(realmService);
     }
 
     protected void unsetRealmService(RealmService realmService) {
 
-        log.debug("Unsetting the Realm Service");
+        LOG.debug("Unsetting the Realm Service");
         SharedUserIdentifierAuthenticatorDataHolder.getInstance().setRealmService(null);
     }
 
@@ -98,9 +93,7 @@ public class SharedUserIdentifierAuthenticatorServiceComponent {
     protected void setOrganizationUserSharingService(
             OrganizationUserSharingService organizationUserSharingService) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Setting the organization user sharing service.");
-        }
+        LOG.debug("Setting the organization user sharing service.");
         SharedUserIdentifierAuthenticatorDataHolder.getInstance()
                 .setOrganizationUserSharingService(organizationUserSharingService);
     }
@@ -108,9 +101,7 @@ public class SharedUserIdentifierAuthenticatorServiceComponent {
     protected void unsetOrganizationUserSharingService(
             OrganizationUserSharingService organizationUserSharingService) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Unsetting the organization user sharing service.");
-        }
+        LOG.debug("Unsetting the organization user sharing service.");
         SharedUserIdentifierAuthenticatorDataHolder.getInstance().setOrganizationUserSharingService(null);
     }
 
@@ -123,17 +114,13 @@ public class SharedUserIdentifierAuthenticatorServiceComponent {
     )
     protected void setOrganizationManager(OrganizationManager organizationManager) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Setting the organization manager service.");
-        }
+        LOG.debug("Setting the organization manager service.");
         SharedUserIdentifierAuthenticatorDataHolder.getInstance().setOrganizationManager(organizationManager);
     }
 
     protected void unsetOrganizationManager(OrganizationManager organizationManager) {
 
-        if (log.isDebugEnabled()) {
-            log.debug("Unsetting the organization manager service.");
-        }
+        LOG.debug("Unsetting the organization manager service.");
         SharedUserIdentifierAuthenticatorDataHolder.getInstance().setOrganizationManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/test/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandlerTest.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/test/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandlerTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.config.ConfigurationFacade;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.ExternalIdPConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorData;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.internal.SharedUserIdentifierAuthenticatorDataHolder;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.tenant.TenantManager;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.HANDLER_FRIENDLY_NAME;
+import static org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.constants.SharedUserIdentifierHandlerConstants.HANDLER_NAME;
+
+/**
+ * Unit test class for {@link SharedUserIdentifierHandler}.
+ */
+public class SharedUserIdentifierHandlerTest {
+
+    private static final String TEST_USERNAME = "testUser";
+    private static final String TEST_TENANT_DOMAIN = "test-tenant.com";
+    private static final String TEST_USER_ID = "test-user-id";
+    private static final String TEST_ORG_ID = "test-org-id";
+    private static final String TEST_RESIDENT_ORG_ID = "resident-org-id";
+    private static final String TEST_ASSOCIATED_USER_ID = "associated-user-id";
+    private static final String TEST_RESIDENT_TENANT_DOMAIN = "resident-tenant.com";
+    private static final String TEST_USER_STORE_DOMAIN = "PRIMARY";
+    private static final String LOGIN_PAGE = "https://localhost:9443/authenticationendpoint/login.do";
+    private static final String QUERY_PARAMS = "sessionDataKey=test-session-key";
+    private static final int TEST_TENANT_ID = 1;
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private AuthenticationContext context;
+    @Mock
+    private ExternalIdPConfig externalIdPConfig;
+    @Mock
+    private SharedUserIdentifierAuthenticatorDataHolder dataHolder;
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private TenantManager tenantManager;
+    @Mock
+    private UserRealm userRealm;
+    @Mock
+    private AbstractUserStoreManager userStoreManager;
+    @Mock
+    private OrganizationManager organizationManager;
+    @Mock
+    private OrganizationUserSharingService organizationUserSharingService;
+
+    private AutoCloseable closeable;
+    private MockedStatic<SharedUserIdentifierAuthenticatorDataHolder> dataHolderStatic;
+    private MockedStatic<LoggerUtils> loggerUtilsStatic;
+    private MockedStatic<FrameworkUtils> frameworkUtilsStatic;
+    private MockedStatic<IdentityUtil> identityUtilStatic;
+    private MockedStatic<ConfigurationFacade> configurationFacadeStatic;
+
+    private SharedUserIdentifierHandler sharedUserIdentifierHandler;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        closeable = MockitoAnnotations.openMocks(this);
+        dataHolderStatic = mockStatic(SharedUserIdentifierAuthenticatorDataHolder.class);
+        loggerUtilsStatic = mockStatic(LoggerUtils.class);
+        frameworkUtilsStatic = mockStatic(FrameworkUtils.class);
+        identityUtilStatic = mockStatic(IdentityUtil.class);
+        configurationFacadeStatic = mockStatic(ConfigurationFacade.class);
+
+        loggerUtilsStatic.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(false);
+        dataHolderStatic.when(SharedUserIdentifierAuthenticatorDataHolder::getInstance).thenReturn(dataHolder);
+
+        when(dataHolder.getRealmService()).thenReturn(realmService);
+        when(dataHolder.getOrganizationManager()).thenReturn(organizationManager);
+        when(dataHolder.getOrganizationUserSharingService()).thenReturn(organizationUserSharingService);
+        when(realmService.getTenantManager()).thenReturn(tenantManager);
+
+        sharedUserIdentifierHandler = spy(new SharedUserIdentifierHandler());
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        configurationFacadeStatic.close();
+        identityUtilStatic.close();
+        frameworkUtilsStatic.close();
+        loggerUtilsStatic.close();
+        dataHolderStatic.close();
+        closeable.close();
+    }
+
+    @Test
+    public void testGetName() {
+
+        Assert.assertEquals(sharedUserIdentifierHandler.getName(), HANDLER_NAME);
+    }
+
+    @Test
+    public void testGetFriendlyName() {
+
+        Assert.assertEquals(sharedUserIdentifierHandler.getFriendlyName(), HANDLER_FRIENDLY_NAME);
+    }
+
+    @Test
+    public void testGetI18nKey() {
+
+        Assert.assertEquals(sharedUserIdentifierHandler.getI18nKey(),
+                "authenticator.shared-user-identifier");
+    }
+
+    @Test
+    public void testIsAPIBasedAuthenticationSupported() {
+
+        Assert.assertTrue(sharedUserIdentifierHandler.isAPIBasedAuthenticationSupported());
+    }
+
+    @DataProvider(name = "canHandleDataProvider")
+    public Object[][] canHandleDataProvider() {
+
+        return new Object[][]{
+                {TEST_USERNAME, true},
+                {"", false},
+                {null, false},
+                {"  ", false},
+        };
+    }
+
+    @Test(dataProvider = "canHandleDataProvider")
+    public void testCanHandle(String username, boolean expectedResult) {
+
+        when(request.getParameter("username")).thenReturn(username);
+        Assert.assertEquals(sharedUserIdentifierHandler.canHandle(request), expectedResult);
+    }
+
+    @Test
+    public void testProcessWithLogoutRequest() throws Exception {
+
+        when(context.isLogoutRequest()).thenReturn(true);
+        AuthenticatorFlowStatus status = sharedUserIdentifierHandler.process(request, response, context);
+        Assert.assertEquals(status, AuthenticatorFlowStatus.SUCCESS_COMPLETED);
+    }
+
+    @Test
+    public void testInitiateAuthenticationRequest() throws Exception {
+
+        setupRedirectStubs();
+        when(context.isRetrying()).thenReturn(false);
+
+        sharedUserIdentifierHandler.initiateAuthenticationRequest(request, response, context);
+
+        ArgumentCaptor<String> redirectCaptor = ArgumentCaptor.forClass(String.class);
+        verify(response).sendRedirect(redirectCaptor.capture());
+        String redirectUrl = redirectCaptor.getValue();
+        Assert.assertTrue(redirectUrl.contains("authenticators=" + HANDLER_NAME + ":LOCAL"));
+    }
+
+    @Test
+    public void testInitiateAuthenticationRequestWithRetry() throws Exception {
+
+        setupRedirectStubs();
+        when(context.isRetrying()).thenReturn(true);
+
+        sharedUserIdentifierHandler.initiateAuthenticationRequest(request, response, context);
+
+        ArgumentCaptor<String> redirectCaptor = ArgumentCaptor.forClass(String.class);
+        verify(response).sendRedirect(redirectCaptor.capture());
+        String redirectUrl = redirectCaptor.getValue();
+        Assert.assertTrue(redirectUrl.contains("authFailure=true"));
+        Assert.assertTrue(redirectUrl.contains("authFailureMsg=login.failed.generic"));
+    }
+
+    @Test(expectedExceptions = AuthenticationFailedException.class)
+    public void testInitiateAuthenticationRequestIOException() throws Exception {
+
+        setupRedirectStubs();
+        when(context.isRetrying()).thenReturn(false);
+        Mockito.doThrow(new IOException("redirect failed")).when(response).sendRedirect(anyString());
+
+        sharedUserIdentifierHandler.initiateAuthenticationRequest(request, response, context);
+    }
+
+    @Test(expectedExceptions = InvalidCredentialsException.class)
+    public void testProcessAuthenticationResponseWithEmptyUsername() throws Exception {
+
+        when(request.getParameter("username")).thenReturn("");
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+    }
+
+    @Test(expectedExceptions = InvalidCredentialsException.class)
+    public void testProcessAuthenticationResponseWithNullUsername() throws Exception {
+
+        when(request.getParameter("username")).thenReturn(null);
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+    }
+
+    @Test
+    public void testProcessAuthenticationResponseUserNotFound() throws Exception {
+
+        setupUserResolutionMocks();
+        when(userStoreManager.getUserIDFromUserName(TEST_USERNAME)).thenReturn(null);
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+
+        ArgumentCaptor<AuthenticatedUser> userCaptor = ArgumentCaptor.forClass(AuthenticatedUser.class);
+        verify(context).setSubject(userCaptor.capture());
+        AuthenticatedUser capturedUser = userCaptor.getValue();
+        Assert.assertEquals(capturedUser.getUserName(), TEST_USERNAME);
+        Assert.assertFalse(capturedUser.isSharedUser());
+    }
+
+    @Test
+    public void testProcessAuthenticationResponseSharedUser() throws Exception {
+
+        setupUserResolutionMocks();
+        when(userStoreManager.getUserIDFromUserName(TEST_USERNAME)).thenReturn(TEST_USER_ID);
+        when(organizationManager.resolveOrganizationId(TEST_TENANT_DOMAIN)).thenReturn(TEST_ORG_ID);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+
+        UserAssociation userAssociation = mock(UserAssociation.class);
+        when(userAssociation.getAssociatedUserId()).thenReturn(TEST_ASSOCIATED_USER_ID);
+        when(userAssociation.getUserResidentOrganizationId()).thenReturn(TEST_RESIDENT_ORG_ID);
+        when(organizationUserSharingService.getUserAssociation(TEST_USER_ID, TEST_ORG_ID))
+                .thenReturn(userAssociation);
+        when(organizationManager.resolveTenantDomain(TEST_RESIDENT_ORG_ID))
+                .thenReturn(TEST_RESIDENT_TENANT_DOMAIN);
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+
+        ArgumentCaptor<AuthenticatedUser> userCaptor = ArgumentCaptor.forClass(AuthenticatedUser.class);
+        verify(context).setSubject(userCaptor.capture());
+        AuthenticatedUser capturedUser = userCaptor.getValue();
+        Assert.assertEquals(capturedUser.getUserName(), TEST_USERNAME);
+        Assert.assertTrue(capturedUser.isSharedUser());
+        Assert.assertEquals(capturedUser.getUserResidentOrganization(), TEST_RESIDENT_ORG_ID);
+        Assert.assertEquals(capturedUser.getTenantDomain(), TEST_RESIDENT_TENANT_DOMAIN);
+        Assert.assertEquals(capturedUser.getAccessingOrganization(), TEST_ORG_ID);
+    }
+
+    @Test
+    public void testProcessAuthenticationResponseNonSharedUser() throws Exception {
+
+        setupUserResolutionMocks();
+        when(userStoreManager.getUserIDFromUserName(TEST_USERNAME)).thenReturn(TEST_USER_ID);
+        when(organizationManager.resolveOrganizationId(TEST_TENANT_DOMAIN)).thenReturn(TEST_ORG_ID);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+        when(organizationUserSharingService.getUserAssociation(TEST_USER_ID, TEST_ORG_ID))
+                .thenReturn(null);
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+
+        ArgumentCaptor<AuthenticatedUser> userCaptor = ArgumentCaptor.forClass(AuthenticatedUser.class);
+        verify(context).setSubject(userCaptor.capture());
+        AuthenticatedUser capturedUser = userCaptor.getValue();
+        Assert.assertEquals(capturedUser.getUserName(), TEST_USERNAME);
+        Assert.assertFalse(capturedUser.isSharedUser());
+    }
+
+    @Test(expectedExceptions = AuthenticationFailedException.class)
+    public void testProcessAuthenticationResponseNullUserRealm() throws Exception {
+
+        when(request.getParameter("username")).thenReturn(TEST_USERNAME);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+        identityUtilStatic.when(() -> IdentityUtil.extractDomainFromName(TEST_USERNAME))
+                .thenReturn(TEST_USER_STORE_DOMAIN);
+        when(tenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(TEST_TENANT_ID);
+        when(realmService.getTenantUserRealm(TEST_TENANT_ID)).thenReturn(null);
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+    }
+
+    @Test(expectedExceptions = AuthenticationFailedException.class)
+    public void testProcessAuthenticationResponseUserStoreException() throws Exception {
+
+        when(request.getParameter("username")).thenReturn(TEST_USERNAME);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+        identityUtilStatic.when(() -> IdentityUtil.extractDomainFromName(TEST_USERNAME))
+                .thenReturn(TEST_USER_STORE_DOMAIN);
+        when(tenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenThrow(
+                new UserStoreException("user store error"));
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+    }
+
+    @Test(expectedExceptions = AuthenticationFailedException.class)
+    public void testProcessAuthenticationResponseOrgManagementException() throws Exception {
+
+        setupUserResolutionMocks();
+        when(userStoreManager.getUserIDFromUserName(TEST_USERNAME)).thenReturn(TEST_USER_ID);
+        when(organizationManager.resolveOrganizationId(TEST_TENANT_DOMAIN))
+                .thenThrow(new OrganizationManagementException("org error"));
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+
+        sharedUserIdentifierHandler.processAuthenticationResponse(request, response, context);
+    }
+
+    @Test
+    public void testGetAuthInitiationData() {
+
+        Optional<AuthenticatorData> result = sharedUserIdentifierHandler.getAuthInitiationData(context);
+
+        Assert.assertTrue(result.isPresent());
+        AuthenticatorData data = result.get();
+        Assert.assertEquals(data.getName(), HANDLER_NAME);
+        Assert.assertEquals(data.getI18nKey(), "authenticator.shared-user-identifier");
+        Assert.assertEquals(data.getDisplayName(), HANDLER_FRIENDLY_NAME);
+        Assert.assertEquals(data.getPromptType(), FrameworkConstants.AuthenticatorPromptType.USER_PROMPT);
+        Assert.assertEquals(data.getRequiredParams().size(), 1);
+        Assert.assertTrue(data.getRequiredParams().contains("username"));
+        Assert.assertEquals(data.getAuthParams().size(), 1);
+    }
+
+    private void setupRedirectStubs() {
+
+        ConfigurationFacade configurationFacade = mock(ConfigurationFacade.class);
+        configurationFacadeStatic.when(ConfigurationFacade::getInstance).thenReturn(configurationFacade);
+        when(configurationFacade.getAuthenticationEndpointURL()).thenReturn(LOGIN_PAGE);
+        when(context.getContextIdIncludedQueryParams()).thenReturn(QUERY_PARAMS);
+        frameworkUtilsStatic.when(() -> FrameworkUtils.appendQueryParamsStringToUrl(anyString(), anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(0) + "?" + invocation.getArgument(1));
+    }
+
+    private void setupUserResolutionMocks() throws Exception {
+
+        when(request.getParameter("username")).thenReturn(TEST_USERNAME);
+        when(context.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+        identityUtilStatic.when(() -> IdentityUtil.extractDomainFromName(TEST_USERNAME))
+                .thenReturn(TEST_USER_STORE_DOMAIN);
+        when(tenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(TEST_TENANT_ID);
+        when(realmService.getTenantUserRealm(TEST_TENANT_ID)).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/test/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandlerTest.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/test/java/org/wso2/carbon/identity/application/authentication/handler/shared/user/identifier/SharedUserIdentifierHandlerTest.java
@@ -48,6 +48,7 @@ import org.wso2.carbon.identity.organization.management.service.exception.Organi
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.config.RealmConfiguration;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.tenant.TenantManager;
 
@@ -105,6 +106,8 @@ public class SharedUserIdentifierHandlerTest {
     private OrganizationManager organizationManager;
     @Mock
     private OrganizationUserSharingService organizationUserSharingService;
+    @Mock
+    private RealmConfiguration realmConfiguration;
 
     private AutoCloseable closeable;
     private MockedStatic<SharedUserIdentifierAuthenticatorDataHolder> dataHolderStatic;
@@ -388,5 +391,8 @@ public class SharedUserIdentifierHandlerTest {
         when(tenantManager.getTenantId(TEST_TENANT_DOMAIN)).thenReturn(TEST_TENANT_ID);
         when(realmService.getTenantUserRealm(TEST_TENANT_ID)).thenReturn(userRealm);
         when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager.getRealmConfiguration()).thenReturn(realmConfiguration);
+        when(realmConfiguration.getUserStoreProperty(anyString())).thenReturn(TEST_USER_STORE_DOMAIN);
+        when(userStoreManager.getSecondaryUserStoreManager()).thenReturn(null);
     }
 }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier">
+
+    <test name="application-authentication-handler-shared-user-identifier-tests">
+        <classes>
+            <class name="org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier.SharedUserIdentifierHandlerTest"/>
+        </classes>
+    </test>
+</suite>

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/pom.xml
@@ -54,6 +54,12 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.platform</groupId>
+                    <artifactId>org.eclipse.equinox.http.service.api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -286,11 +286,27 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
         if (!context.getProperties().containsKey(ORGANIZATION_LOGIN_FAILURE)) {
             super.processAuthenticationResponse(request, response, context);
 
-            // Add organization name to the user attributes.
-            context.getSubject().getUserAttributes()
-                    .put(ClaimMapping.build(USER_ORGANIZATION_CLAIM, USER_ORGANIZATION_CLAIM, null, false),
-                            context.getAuthenticatorProperties().get(ORGANIZATION_ATTRIBUTE));
+            // Check if the resident organization can be resolved via user attributes from federated response.
+            // If not, set the user organization in the user attributes to be used by downstream services.
+            if (!canResolveResidentOrganizationViaAttributes(context.getSubject().getUserAttributes())) {
+                context.getSubject().getUserAttributes()
+                        .put(ClaimMapping.build(USER_ORGANIZATION_CLAIM, USER_ORGANIZATION_CLAIM, null, false),
+                                context.getAuthenticatorProperties().get(ORGANIZATION_ATTRIBUTE));
+            }
         }
+    }
+
+    private boolean canResolveResidentOrganizationViaAttributes(Map<ClaimMapping, String> userAttributes) {
+
+        for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
+            ClaimMapping claimMapping = entry.getKey();
+            if (FrameworkConstants.USER_ORG_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri()) ||
+            FrameworkConstants.ORG_ID_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri())) {
+              return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.organization.login/src/main/java/org/wso2/carbon/identity/application/authenticator/organization/login/OrganizationAuthenticator.java
@@ -301,8 +301,8 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
         for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
             ClaimMapping claimMapping = entry.getKey();
             if (FrameworkConstants.USER_ORG_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri()) ||
-            FrameworkConstants.ORG_ID_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri())) {
-              return true;
+                    FrameworkConstants.ORG_ID_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri())) {
+                return true;
             }
         }
 

--- a/features/org.wso2.carbon.identity.auth.organization.login.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.auth.organization.login.server.feature/pom.xml
@@ -39,6 +39,10 @@
             <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
             <artifactId>org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -65,6 +69,7 @@
                             <bundles>
                                 <bundleDef>org.wso2.carbon.identity.auth.organization.login:org.wso2.carbon.identity.application.authenticator.organization.login</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.auth.organization.login:org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.auth.organization.login:org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier</bundleDef>
                             </bundles>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.10.84</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.59</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <modules>
         <module>components/org.wso2.carbon.identity.application.authenticator.organization.login</module>
         <module>components/org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</module>
+        <module>components/org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier</module>
         <module>features/org.wso2.carbon.identity.auth.organization.login.server.feature</module>
     </modules>
 
@@ -149,6 +150,22 @@
                 <artifactId>org.wso2.carbon.identity.application.authenticator.handler.organization.identifier</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.auth.organization.login</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+                <version>${carbon.identity.org.mgt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.base</artifactId>
+                <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.orbit.com.nimbusds</groupId>
@@ -394,7 +411,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.10.36</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.84</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
This pull request introduces a new "Shared User Identifier" authentication handler. This handler will be responsible for identifying if the logging in user is a shared user to the accessing organization and resolving the resident user information. It also includes a dependency exclusion to prevent conflicts and enhances the organization authenticator logic to better handle organization attribute resolution.

**Addition of Shared User Identifier Handler:**

* Added a new Maven module `org.wso2.carbon.identity.application.authentication.handler.shared.user.identifier` with its own `pom.xml`, dependencies, and OSGi bundle configuration.
* Implemented constants, error messages, and log identifiers in `SharedUserIdentifierHandlerConstants.java` for consistent use across the handler.
* Added a singleton data holder (`SharedUserIdentifierAuthenticatorDataHolder.java`) to manage service references required by the handler.
* Registered the handler as an OSGi component and managed service dependencies in `SharedUserIdentifierAuthenticatorServiceComponent.java`.

**Integration and Dependency Management:**

* Integrated the new handler as a dependency and bundle in the server feature (`org.wso2.carbon.identity.auth.organization.login.server.feature/pom.xml`). 
* Updated the organization login authenticator's `pom.xml` to exclude a conflicting dependency (`org.eclipse.equinox.http.service.api`).

**Enhancement to Organization Authenticator Logic:**

* Improved organization attribute handling in the authentication response to check for existing organization claims before setting the organization attribute, reducing redundant attribute assignments.

### Dependent on
- https://github.com/wso2/carbon-identity-framework/pull/7964

### Related issue
- https://github.com/wso2/product-is/issues/27371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared-user identifier authentication handler for username-initiated organization login and shared-user resolution.

* **Bug Fixes**
  * Organization authenticator now preserves existing organization claim data before populating organization attributes.

* **Tests**
  * Added unit tests covering handler initiation, response processing, retries, shared-user resolution, and error cases.

* **Packaging**
  * New module added and server feature updated to include and ship the shared-user identifier handler; build/dependency metadata updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->